### PR TITLE
add urldecode to request path to be able to write valid files for req…

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ function rewrite(apiPath, extensions, req, next) {
 	const url = req.url.split("?");
 	const b = `${url[0]}/${req.method}`;
 	const mapped = extensions.some(ext => {
-		const resourcePath = url[1] ? `${b}_${url[1]}.${ext}` : `${b}.${ext}`;
+		const resourcePath = url[1] ? `${b}_${decodeURIComponent(url[1])}.${ext}` : `${b}.${ext}`;
 		const filePath = Path.posix.join(apiPath, resourcePath);
 		if (FS.existsSync(filePath)) {
 			req.url = resourcePath;


### PR DESCRIPTION
…uest string

Example:
real GET url: http://localhost:8080/api/v2/messages/history?message%5Brecipient%5D=a965bbaafd4c2d94cc71cf6209fcb4428b07a305
is neither mapped to /messages/history/GET_message%5Brecipient%5D=a965bbaafd4c2d94cc71cf6209fcb4428b07a305.json
nor to /messages/history/GET_message[recipient]=a965bbaafd4c2d94cc71cf6209fcb4428b07a305.json

with this change it's working with /messages/history/GET_message[recipient]=a965bbaafd4c2d94cc71cf6209fcb4428b07a305.json